### PR TITLE
Stop the build if there are Python syntax errors or undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@
   "language": "python",
   "python": "3.6",
   "install": [
-    "pip install -r requirements.txt"
+    "pip install -r requirements.txt",
+    "pip install flake8"
   ],
+  "before_script": "flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics",
   "script": "nosetests",
   "after_success": [
     "codecov"


### PR DESCRIPTION
Use flake8 to stop the build if there are Python syntax errors or undefined names